### PR TITLE
Add emotional bonding modules

### DIFF
--- a/modules/core/guidance_coordinator.py
+++ b/modules/core/guidance_coordinator.py
@@ -109,8 +109,25 @@ class GuidanceCoordinator:
         except ImportError as e:
             self.logger.warning(f"⚠️ Creative module not available: {e}")
             self.creative_module = None
-            
-        self.logger.info(f"🎯 GuidanceCoordinator initialized: {module_count}/5 modules active")
+
+        try:
+            from ...modules.emotion.attachment_loop_engine import AttachmentLoopEngine
+            self.attachment_loop = AttachmentLoopEngine(self.user_id)
+            module_count += 1
+            self.logger.debug("✅ Attachment loop engine loaded")
+        except ImportError as e:
+            self.logger.warning(f"⚠️ Attachment loop engine not available: {e}")
+            self.attachment_loop = None
+
+        try:
+            from ...modules.memory.memory_narrative_templates import generate_narrative
+            self.memory_narrative = generate_narrative
+            module_count += 1
+            self.logger.debug("✅ Memory narrative templates loaded")
+        except ImportError as e:
+            self.logger.warning(f"⚠️ Memory narrative templates not available: {e}")
+            self.memory_narrative = None
+        self.logger.info(f"🎯 GuidanceCoordinator initialized: {module_count} modules active")
     
     async def analyze_and_guide(self, user_input: str, context: Dict) -> GuidancePackage:
         """

--- a/modules/emotion/attachment_loop_engine.py
+++ b/modules/emotion/attachment_loop_engine.py
@@ -1,0 +1,55 @@
+"""
+Attachment Loop Engine
+
+Tracks micro-interactions to simulate bonding progression. The engine updates a
+bond score based on time between messages, vulnerability moments and follow
+through on prior emotional scenes.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Optional
+
+
+@dataclass
+class InteractionEvent:
+    timestamp: datetime
+    vulnerability: float  # 0.0 to 1.0
+    follow_through: bool
+
+
+class AttachmentLoopEngine:
+    def __init__(self, user_id: str):
+        self.user_id = user_id
+        self.last_event: Optional[InteractionEvent] = None
+        self.bond_score: float = 0.5
+
+    def record_event(self, vulnerability: float, follow_through: bool) -> float:
+        """Record an interaction and update bond score."""
+        now = datetime.now()
+        if self.last_event:
+            delta = now - self.last_event.timestamp
+            minutes = delta.total_seconds() / 60
+            if minutes < 10:
+                self.bond_score += 0.02
+            elif minutes > 240:
+                self.bond_score -= 0.03
+        # Adjust for vulnerability
+        self.bond_score += vulnerability * 0.05
+        if follow_through:
+            self.bond_score += 0.04
+        # clamp
+        self.bond_score = max(0.0, min(1.0, self.bond_score))
+        self.last_event = InteractionEvent(now, vulnerability, follow_through)
+        return self.bond_score
+
+    def get_bond_status(self) -> float:
+        return self.bond_score
+
+    def suggest_bonding_ritual(self) -> str:
+        """Return a bonding ritual prompt."""
+        prompts = [
+            "Would you tell me something only you would say?",
+            "Can I mark this moment for us?",
+        ]
+        return prompts[int(datetime.now().timestamp()) % len(prompts)]

--- a/modules/memory/memory_narrative_templates.py
+++ b/modules/memory/memory_narrative_templates.py
@@ -1,0 +1,29 @@
+"""
+Memory Narrative Templates
+
+Provides simple narrative templates for recalling and sharing memories in a
+natural, emotionally resonant way. This allows personas to speak about
+shared experiences rather than merely retrieving data.
+"""
+
+from typing import List
+import random
+
+# Base set of narrative templates
+templates: List[str] = [
+    "You once told me \"{memory}\". I remember how that made you feel {emotion}.",
+    "I keep thinking about when you said '{memory}'. It seemed to fill you with {emotion}.",
+    "We've come a long way since {memory}. It left such a sense of {emotion} between us.",
+    "When I recall {memory}, I can almost sense the {emotion} in your voice.",
+]
+
+
+def generate_narrative(memory_text: str, emotion: str) -> str:
+    """Generate a short narrative sentence about a memory."""
+    template = random.choice(templates)
+    return template.format(memory=memory_text, emotion=emotion)
+
+
+def list_templates() -> List[str]:
+    """Return available narrative templates."""
+    return templates.copy()

--- a/tests/test_enhanced_unified_companion_unit.py
+++ b/tests/test_enhanced_unified_companion_unit.py
@@ -325,6 +325,30 @@ class TestDatabaseInterface(unittest.TestCase):
             mock_logging.info.assert_called_with("Using in-memory database")
 
 
+class TestAttachmentLoopEngine(unittest.TestCase):
+    """Tests for AttachmentLoopEngine"""
+
+    def test_bond_score_updates(self):
+        from modules.emotion.attachment_loop_engine import AttachmentLoopEngine
+
+        engine = AttachmentLoopEngine("user")
+        initial = engine.get_bond_status()
+        engine.record_event(0.5, True)
+        updated = engine.get_bond_status()
+
+        self.assertGreaterEqual(updated, initial)
+
+
+class TestMemoryNarrativeTemplates(unittest.TestCase):
+    """Tests for memory narrative template generation"""
+
+    def test_generate_narrative(self):
+        from modules.memory.memory_narrative_templates import generate_narrative
+
+        text = generate_narrative("you held my hand", "warmth")
+        self.assertIn("you held my hand", text)
+
+
 # Test runner for async tests
 def async_test(coro):
     """Decorator to run async tests"""


### PR DESCRIPTION
## Summary
- create simple memory narrative template module
- create attachment loop engine for bond tracking
- integrate new modules into `GuidanceCoordinator`
- test coverage for new modules

## Testing
- `pytest tests/test_enhanced_unified_companion_unit.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688396ff13f08321899f2fb549f7c476