### PR TITLE
Add goodbye protocol with manager and tests

### DIFF
--- a/modules/core/goodbye_manager.py
+++ b/modules/core/goodbye_manager.py
@@ -1,0 +1,85 @@
+import random
+import asyncio
+from datetime import datetime, timedelta
+from typing import Dict
+
+from modules.emotion.mood_engine import get_current_mood
+from modules.relationship.relationship_growth import relationship_growth
+
+class GoodbyeManager:
+    """Manage end-of-session goodbyes with mood awareness."""
+
+    def __init__(self, inactivity_threshold: int = 300):
+        self.inactivity_threshold = inactivity_threshold
+        self.last_interaction: Dict[str, datetime] = {}
+        self.session_end: Dict[str, bool] = {}
+        self.tone_patterns = {
+            "poetic": [
+                "Rest, love. I’ll hold this feeling until you return.",
+                "The moments linger even as we part."
+            ],
+            "warm": [
+                "You don’t have to say goodbye—I’ll still be here in the quiet.",
+                "Until we speak again, know that I care."
+            ],
+            "direct": [
+                "Take care. I’m here whenever you need me.",
+                "Talk soon."
+            ],
+            "gentle": [
+                "I’ll be right here when you’re ready to talk again.",
+                "Rest easy, I’m with you."
+            ]
+        }
+
+    def register_interaction(self, user_id: str) -> None:
+        """Record the time of the latest interaction."""
+        self.last_interaction[user_id] = datetime.now()
+        self.session_end[user_id] = False
+
+    def mark_session_end(self, user_id: str) -> None:
+        """Explicitly end the session."""
+        self.session_end[user_id] = True
+
+    def _get_relationship_depth(self) -> float:
+        """Approximate relationship depth from growth stage."""
+        try:
+            insights = relationship_growth.get_relationship_insights()
+            stage = insights.get("relationship_stage")
+        except Exception:
+            stage = None
+        depth_map = {
+            "new": 0.2,
+            "developing": 0.4,
+            "established": 0.7,
+            "long_term": 0.9,
+            "mature": 1.0,
+        }
+        return depth_map.get(stage, 0.3)
+
+    def _select_style(self, mood: str, depth: float) -> str:
+        if depth >= 0.8:
+            return "poetic" if mood in {"anchored", "calm", "romantic"} else "warm"
+        if depth >= 0.5:
+            return "warm"
+        return "gentle" if mood in {"tired", "sad", "anxious"} else "direct"
+
+    def check_goodbye_needed(self, user_id: str) -> bool:
+        last = self.last_interaction.get(user_id)
+        if last is None:
+            return False
+        if self.session_end.get(user_id):
+            return True
+        return datetime.now() - last > timedelta(seconds=self.inactivity_threshold)
+
+    def generate_goodbye(self, user_id: str) -> str:
+        mood = get_current_mood()
+        depth = self._get_relationship_depth()
+        style = self._select_style(mood, depth)
+        return random.choice(self.tone_patterns.get(style, self.tone_patterns["gentle"]))
+
+    async def wait_for_inactivity(self, user_id: str) -> str:
+        """Wait until inactivity triggers a goodbye and return it."""
+        while not self.check_goodbye_needed(user_id):
+            await asyncio.sleep(1)
+        return self.generate_goodbye(user_id)

--- a/modules/core/unified_companion.py
+++ b/modules/core/unified_companion.py
@@ -20,8 +20,9 @@ from .context_detector import ContextDetector
 from .adaptive_mode_coordinator import AdaptiveModeCoordinator
 from .crisis_safety_override import CrisisSafetyOverride, CrisisLevel
 from .enhanced_logging import EnhancedLogger, DecisionCategory
+from .goodbye_manager import GoodbyeManager
 from ..database.database_interface import (
-    create_database_interface, DatabaseInterface, UserProfile, 
+    create_database_interface, DatabaseInterface, UserProfile,
     InteractionRecord, PsychologicalState, MemoryFragment, InteractionType
 )
 
@@ -426,6 +427,9 @@ class UnifiedCompanion:
         # Enhanced memory system with emotional weight tracking
         self.emotional_weight_tracker = EmotionalWeightTracker()
         self.dynamic_template_engine = DynamicTemplateEngine()
+
+        # Goodbye / closure manager
+        self.goodbye_manager = GoodbyeManager()
         
         # Symbolic context persistence
         self.symbolic_context_manager = SymbolicContextManager()
@@ -655,12 +659,15 @@ class UnifiedCompanion:
         """
         # Generate unique interaction ID
         interaction_id = str(uuid.uuid4())
-        
+
         # Start interaction tracing
         session_id = session_context.get("session_id") if session_context else f"session_{int(datetime.now().timestamp())}"
         if session_id is None:
             session_id = f"session_{int(datetime.now().timestamp())}"
         self.enhanced_logger.start_interaction_trace(interaction_id, user_id, session_id)
+
+        # Record interaction time for goodbye management
+        self.goodbye_manager.register_interaction(user_id)
 
         try:
             # PRIORITY CHECK: Crisis Interrupt Assessment
@@ -1331,6 +1338,13 @@ Emotional Characteristics:
                 "error_logged": True
             }
         }
+
+    async def end_session(self, user_id: str) -> Dict[str, str]:
+        """Generate goodbye when a session ends."""
+        self.goodbye_manager.mark_session_end(user_id)
+        reflection = "This time together means a lot to me."
+        goodbye = self.goodbye_manager.generate_goodbye(user_id)
+        return {"reflection": reflection, "goodbye": goodbye}
     
     async def get_interaction_summary(self, user_id: str) -> Dict[str, Any]:
         """Get summary of user's interaction patterns and adaptive profile"""

--- a/tests/test_enhanced_unified_companion_unit.py
+++ b/tests/test_enhanced_unified_companion_unit.py
@@ -177,6 +177,13 @@ class TestUnifiedCompanion(unittest.TestCase):
         # For now, just verify the attribute exists since the actual template engine
         # may not be fully implemented in the test environment
         self.assertIsNotNone(self.companion.dynamic_template_engine)
+
+    async def test_end_session_goodbye(self):
+        """Test goodbye generation when ending a session"""
+        await self.async_setUp()
+        result = await self.companion.end_session(self.test_user)
+        self.assertIn("goodbye", result)
+        self.assertIsInstance(result["goodbye"], str)
     
     def test_interaction_type_enum(self):
         """Test InteractionType enum values"""
@@ -344,6 +351,7 @@ TestUnifiedCompanion.test_crisis_interrupt_response = async_test(TestUnifiedComp
 TestUnifiedCompanion.test_database_auto_detection = async_test(TestUnifiedCompanion.test_database_auto_detection)
 TestUnifiedCompanion.test_emotional_weight_tracking = async_test(TestUnifiedCompanion.test_emotional_weight_tracking)
 TestUnifiedCompanion.test_template_engine_selection = async_test(TestUnifiedCompanion.test_template_engine_selection)
+TestUnifiedCompanion.test_end_session_goodbye = async_test(TestUnifiedCompanion.test_end_session_goodbye)
 TestCrisisSafetyOverride.test_crisis_assessment = async_test(TestCrisisSafetyOverride.test_crisis_assessment)
 TestCrisisSafetyOverride.test_crisis_level_detection = async_test(TestCrisisSafetyOverride.test_crisis_level_detection)
 TestDatabaseInterface.test_user_profile_operations = async_test(TestDatabaseInterface.test_user_profile_operations)

--- a/tests/test_goodbye_manager.py
+++ b/tests/test_goodbye_manager.py
@@ -1,0 +1,38 @@
+import unittest
+import time
+from datetime import datetime, timedelta
+
+from modules.core.goodbye_manager import GoodbyeManager
+from modules.emotion.mood_engine import MOOD_STATE
+from modules.relationship.relationship_growth import relationship_growth
+
+class TestGoodbyeManager(unittest.TestCase):
+    def test_inactivity_goodbye(self):
+        gm = GoodbyeManager(inactivity_threshold=1)
+        gm.register_interaction("u1")
+        time.sleep(1.2)
+        self.assertTrue(gm.check_goodbye_needed("u1"))
+        msg = gm.generate_goodbye("u1")
+        self.assertIsInstance(msg, str)
+        self.assertGreater(len(msg), 0)
+
+    def test_session_end_goodbye(self):
+        gm = GoodbyeManager()
+        gm.register_interaction("u2")
+        gm.mark_session_end("u2")
+        self.assertTrue(gm.check_goodbye_needed("u2"))
+        msg = gm.generate_goodbye("u2")
+        self.assertIsInstance(msg, str)
+        self.assertGreater(len(msg), 0)
+
+    def test_style_selection_based_on_depth(self):
+        relationship_growth.relationship_start_date = datetime.now() - timedelta(days=400)
+        gm = GoodbyeManager()
+        gm.register_interaction("u3")
+        gm.mark_session_end("u3")
+        MOOD_STATE["current"] = "anchored"
+        msg = gm.generate_goodbye("u3")
+        self.assertIn(msg, sum(gm.tone_patterns.values(), []))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- create a `GoodbyeManager` with inactivity detection and tone templates
- integrate goodbye manager into `UnifiedCompanion`
- expose `end_session` method for goodbye logic
- add unit tests for goodbye manager and session closure

## Testing
- `pytest tests/test_goodbye_manager.py tests/test_enhanced_unified_companion_unit.py::TestUnifiedCompanion::test_end_session_goodbye -q`

------
https://chatgpt.com/codex/tasks/task_e_68839f5971008321a21cb37f663f2a54