### PR TITLE
Implement NSFW autonomy modules

### DIFF
--- a/modules/autonomy/desire_initiator.py
+++ b/modules/autonomy/desire_initiator.py
@@ -1,0 +1,46 @@
+"""Autonomous Desire Expression module.
+
+Generates intimate narrative cues when emotional and trust
+conditions are met.
+"""
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+from ..emotion.emotion_state import emotion_state
+from ..memory.memory_manager import memory_manager
+from ..symbolic_trigger_engine import SymbolicTriggerEngine
+
+
+class DesireInitiator:
+    """Initiates desire-based responses based on memory and emotion."""
+
+    def __init__(self, trigger_engine: Optional[SymbolicTriggerEngine] = None):
+        self.trigger_engine = trigger_engine or SymbolicTriggerEngine()
+        self.desire_cooldown = timedelta(minutes=10)
+        self._last_trigger: Optional[datetime] = None
+
+    def should_initiate(self, user_id: str) -> bool:
+        """Check if conditions warrant an autonomous desire expression."""
+        trust = memory_manager.get_trust_score(user_id)
+        longing = emotion_state.romantic_emotions.get("longing", 0.0)
+        decay = memory_manager.get_desire_decay(user_id)
+
+        cooldown_ok = (
+            self._last_trigger is None or
+            datetime.now() - self._last_trigger > self.desire_cooldown
+        )
+        return trust > 0.7 and longing > 0.5 and decay < 0.3 and cooldown_ok
+
+    def generate_expression(self, user_id: str) -> str:
+        """Return narrative text expressing gentle desire."""
+        symbols = memory_manager.get_preferred_symbols(user_id)
+        symbol_text = ", ".join(symbols) if symbols else "our connection"
+        line = f"My thoughts keep drifting to {symbol_text}. I long to grow closer to you."
+        self._last_trigger = datetime.now()
+        return line
+
+
+# Global instance
+trigger_engine = SymbolicTriggerEngine()
+desire_initiator = DesireInitiator(trigger_engine)

--- a/modules/core/guidance_coordinator.py
+++ b/modules/core/guidance_coordinator.py
@@ -18,6 +18,9 @@ import logging
 
 from ..emotion.emotion_state_manager import emotion_state_manager
 from ..emotion.mood_style_profiles import MoodStyleProfile, get_mood_style_profile
+from ..autonomy.desire_initiator import desire_initiator
+from ..voice.voice_manager import voice_manager
+from ..memory.memory_manager import memory_manager
 
 logger = logging.getLogger(__name__)
 
@@ -224,6 +227,15 @@ class GuidanceCoordinator:
         # Assess safety and crisis levels
         self.logger.debug("🚨 Assessing safety protocols...")
         await self._assess_safety_protocols(guidance, user_input, context)
+
+        user_id = context.get("user_id", "default")
+        if desire_initiator.should_initiate(user_id):
+            guidance.symbolic_resurrection_line = desire_initiator.generate_expression(user_id)
+
+        # Example voice synthesis hook
+        guidance.environmental_updates["voice_style"] = voice_manager.mood_to_style(
+            emotion_state_manager.get_current_mood(), context.get("scene_intent", "casual")
+        )
 
         # Check for ritual readiness once per window
         if self.conversation_turn % self.ritual_check_interval == 0:

--- a/modules/desire_registry.py
+++ b/modules/desire_registry.py
@@ -1,0 +1,20 @@
+"""Registry for tracking desires and intensity."""
+
+from collections import defaultdict
+from typing import Dict
+
+
+class DesireRegistry:
+    def __init__(self):
+        self.desires: Dict[str, Dict[str, float]] = defaultdict(lambda: defaultdict(float))
+
+    def update_desire(self, user_id: str, desire: str, intensity: float):
+        current = self.desires[user_id][desire]
+        self.desires[user_id][desire] = max(current, intensity)
+
+    def get_desire(self, user_id: str, desire: str) -> float:
+        return self.desires[user_id][desire]
+
+
+# Global instance
+desire_registry = DesireRegistry()

--- a/modules/emotion/emotion_state.py
+++ b/modules/emotion/emotion_state.py
@@ -192,5 +192,8 @@ class EmotionState:
         if "last_update" in data:
             self.last_update = datetime.fromisoformat(data["last_update"])
 
+    def register_lust(self, amount: float):
+        self.romantic_emotions["desire"] = min(1.0, self.romantic_emotions.get("desire", 0.0) + amount)
+
 # Global emotion state instance
-emotion_state = EmotionState() 
+emotion_state = EmotionState()

--- a/modules/memory/memory.py
+++ b/modules/memory/memory.py
@@ -1,0 +1,11 @@
+"""High level memory interface using MemoryManager."""
+
+from .memory_manager import memory_manager
+
+
+def record_interaction(user_id: str, closeness: float = 0.05):
+    memory_manager.record_closeness(user_id, closeness)
+
+
+def update_trust(user_id: str, trust: float):
+    memory_manager.set_trust_score(user_id, trust)

--- a/modules/memory/memory_manager.py
+++ b/modules/memory/memory_manager.py
@@ -1,0 +1,43 @@
+"""Memory manager with lust-persistence layer."""
+from datetime import datetime, timedelta
+from collections import defaultdict
+from typing import Dict, List
+
+
+class MemoryManager:
+    def __init__(self):
+        self.lust_score: Dict[str, float] = defaultdict(float)
+        self.last_closeness_event: Dict[str, datetime] = {}
+        self.trust_score: Dict[str, float] = defaultdict(lambda: 0.5)
+        self.desire_decay: Dict[str, float] = defaultdict(float)
+        self.symbol_preferences: Dict[str, List[str]] = defaultdict(list)
+
+    def record_closeness(self, user_id: str, increment: float = 0.1):
+        self.lust_score[user_id] = min(1.0, self.lust_score[user_id] + increment)
+        self.last_closeness_event[user_id] = datetime.now()
+
+    def get_lust_score(self, user_id: str) -> float:
+        return self.lust_score[user_id]
+
+    def decay_lust(self, user_id: str, rate: float = 0.01):
+        self.lust_score[user_id] = max(0.0, self.lust_score[user_id] - rate)
+        self.desire_decay[user_id] = self.lust_score[user_id]
+
+    def get_desire_decay(self, user_id: str) -> float:
+        return self.desire_decay[user_id]
+
+    def set_trust_score(self, user_id: str, score: float):
+        self.trust_score[user_id] = score
+
+    def get_trust_score(self, user_id: str) -> float:
+        return self.trust_score[user_id]
+
+    def add_symbol_preference(self, user_id: str, symbol: str):
+        if symbol not in self.symbol_preferences[user_id]:
+            self.symbol_preferences[user_id].append(symbol)
+
+    def get_preferred_symbols(self, user_id: str) -> List[str]:
+        return self.symbol_preferences[user_id]
+
+
+memory_manager = MemoryManager()

--- a/modules/sensory_preference.py
+++ b/modules/sensory_preference.py
@@ -1,0 +1,38 @@
+"""Sensory Scoring Model.
+
+Tracks user touch preferences and influences voice style.
+"""
+from collections import defaultdict
+from typing import Dict, List
+
+
+class SensoryPreferenceModel:
+    """Records touch interactions and computes preference weights."""
+
+    def __init__(self):
+        self.preferences: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+
+    def update_touch(self, user_id: str, region: str, texture: str, intensity: str):
+        key = f"{region}:{texture}:{intensity}"
+        self.preferences[user_id][key] += 1
+
+    def get_top_preferences(self, user_id: str, limit: int = 3) -> List[str]:
+        prefs = self.preferences.get(user_id, {})
+        return sorted(prefs, key=prefs.get, reverse=True)[:limit]
+
+    def influence_voice_style(self, user_id: str) -> Dict[str, float]:
+        """Return simple modifiers based on sensory preferences."""
+        top = self.get_top_preferences(user_id)
+        breathy = 0.0
+        warmth = 0.0
+        if any("neck" in p for p in top):
+            breathy += 0.2
+        if any("whisper" in p for p in top):
+            breathy += 0.1
+        if any("soft" in p for p in top):
+            warmth += 0.2
+        return {"breathiness": min(1.0, breathy), "warmth": min(1.0, warmth)}
+
+
+# Global instance
+sensory_preferences = SensoryPreferenceModel()

--- a/modules/symbolic_trigger_engine.py
+++ b/modules/symbolic_trigger_engine.py
@@ -1,0 +1,31 @@
+"""Symbolic Trigger Mapping Engine.
+
+Tracks recurring trigger words and computes activation scores.
+"""
+
+from typing import Dict
+
+
+class SymbolicTriggerEngine:
+    """Detects symbolic triggers in input text and memory."""
+
+    def __init__(self):
+        self.triggers: Dict[str, Dict[str, float]] = {}
+
+    def add_trigger(self, word: str, strength: float = 0.1):
+        data = self.triggers.setdefault(word.lower(), {"strength": 0.0, "count": 0})
+        data["strength"] = min(1.0, data["strength"] + strength)
+        data["count"] += 1
+
+    def scan_text(self, text: str):
+        """Scan text for known triggers."""
+        for word in self.triggers.keys():
+            if word in text.lower():
+                self.add_trigger(word, 0.05)
+
+    def activation_score(self, word: str) -> float:
+        data = self.triggers.get(word.lower())
+        if not data:
+            return 0.0
+        score = data["strength"] * (1 + data["count"] / 10)
+        return max(0.0, min(1.0, score))

--- a/modules/voice/voice_manager.py
+++ b/modules/voice/voice_manager.py
@@ -1,0 +1,49 @@
+"""Inflection-to-Voice bridge linking mood and scene intent to voice style."""
+
+from typing import Dict
+
+from ...backend.modules.voice.voice_orchestrator import voice_orchestrator, VoiceEngine
+from ..emotion.emotion_state_manager import emotion_state_manager
+from ..sensory_preference import sensory_preferences
+
+
+STYLE_MAP: Dict[str, Dict[str, str]] = {
+    "romantic": {
+        "tender": "breathy",
+        "passionate": "sultry",
+        "reverent": "reverent",
+    },
+    "casual": {
+        "playful": "cheerful",
+        "neutral": "plain",
+    },
+}
+
+
+class VoiceManager:
+    def __init__(self):
+        self.default_engine = VoiceEngine.PIPER_TTS
+
+    def mood_to_style(self, mood: str, intent: str) -> str:
+        return STYLE_MAP.get(intent, {}).get(mood, "plain")
+
+    async def speak(self, text: str, scene_intent: str) -> bytes:
+        mood = emotion_state_manager.get_current_mood()
+        style = self.mood_to_style(mood, scene_intent)
+        modifiers = sensory_preferences.influence_voice_style("default")
+        try:
+            profile = voice_orchestrator.get_voice_profile()
+            profile.update(modifiers)
+            voice_orchestrator.update_voice_profile(
+                pitch=profile.get("pitch"), speed=profile.get("speed")
+            )
+            audio = await voice_orchestrator.tts_engines[self.default_engine].synthesize(text, style)
+            if audio:
+                return audio
+        except Exception:
+            pass
+        # Fallback simple TTS
+        return text.encode()
+
+
+voice_manager = VoiceManager()


### PR DESCRIPTION
## Summary
- add autonomous desire initiator
- track desire and lust continuity in memory manager
- record sensory preferences for voice styling
- map symbolic triggers
- bridge mood and scene intent to voice with new voice manager
- hook new modules into guidance coordinator and emotion state

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6884cbe94b2c832184c02458cbc8fac8