### PR TITLE
Streamline gateway configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,6 @@ ENCRYPTION_KEY=your_encryption_key_here
 # Logging
 LOG_LEVEL=INFO
 DEBUG_MODE=false
+# Gateway
+ALLOWED_ORIGINS=http://localhost:3000
+VITE_GATEWAY_URL=http://localhost:5000

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ OPENROUTER_KEY=your_openrouter_key_here
 
 # Optional: n8n Integration
 N8N_URL=http://192.168.50.159:5678
+# Frontend Gateway URL
+VITE_GATEWAY_URL=http://localhost:5000
+# Allowed Origins for Gateway
+ALLOWED_ORIGINS=http://localhost:3000
 ```
 
 ### 3. Start the System
@@ -107,10 +111,10 @@ npm run dev
 ```
 
 ### 4. Access the System
-- **Frontend UI**: http://192.168.50.234:3000 (or 5173 for Vite)
-- **API Gateway**: http://192.168.50.234:5000
+- **Frontend UI**: http://localhost:3000 (or 5173 for Vite)
+- **API Gateway**: `http://localhost:5000` (configurable via `VITE_GATEWAY_URL`)
 - **Dolphin Backend**: http://192.168.50.159:8000
-- **Health Check**: http://192.168.50.234:5000/health
+- **Health Check**: `http://localhost:5000/health`
 ## 🎭 Using Personas
 
 ### Built-in Personas

--- a/core1-gateway/server.js
+++ b/core1-gateway/server.js
@@ -7,8 +7,9 @@ require('dotenv').config();
 const app = express();
 const PORT = process.env.PORT || 5000;
 const DOLPHIN_BACKEND = process.env.DOLPHIN_BACKEND || 'http://localhost:8000';
+const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS || '*';
 
-app.use(cors());
+app.use(cors({ origin: ALLOWED_ORIGINS.split(',') }));
 app.use(express.json());
 
 // Enhanced session management

--- a/core1-gateway/src/App.jsx
+++ b/core1-gateway/src/App.jsx
@@ -4,6 +4,8 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
 
+const API_BASE = import.meta.env.VITE_GATEWAY_URL || 'http://localhost:5000';
+
 export default function App() {
   const [message, setMessage] = useState('');
   const [messages, setMessages] = useState([]);
@@ -25,20 +27,20 @@ export default function App() {
     const initializeApp = async () => {
       try {
         // Get system status
-        const statusRes = await axios.get('http://192.168.50.234:5000/api/status');
+        const statusRes = await axios.get(`${API_BASE}/api/status`);
         setStatus(statusRes.data);
         
         // Get available handlers
-        const handlersRes = await axios.get('http://192.168.50.234:5000/api/handlers');
+        const handlersRes = await axios.get(`${API_BASE}/api/handlers`);
         setHandlers(handlersRes.data.handlers);
         
         // Get available personas
-        const personasRes = await axios.get('http://192.168.50.234:5000/api/personas');
+        const personasRes = await axios.get(`${API_BASE}/api/personas`);
         setPersonas(Object.entries(personasRes.data.personas));
         setCurrentPersona(personasRes.data.current_persona);
         
         // Get real-time analytics
-        const analyticsRes = await axios.get('http://192.168.50.234:5000/api/analytics/realtime');
+        const analyticsRes = await axios.get(`${API_BASE}/api/analytics/realtime`);
         setAnalytics(analyticsRes.data);
         
       } catch (err) {
@@ -51,7 +53,7 @@ export default function App() {
     // Set up periodic status updates
     const interval = setInterval(async () => {
       try {
-        const analyticsRes = await axios.get('http://192.168.50.234:5000/api/analytics/realtime');
+        const analyticsRes = await axios.get(`${API_BASE}/api/analytics/realtime`);
         setAnalytics(analyticsRes.data);
       } catch (err) {
         // Silently handle polling errors
@@ -63,7 +65,7 @@ export default function App() {
 
   const handlePersonaChange = async (personaId) => {
     try {
-      await axios.post(`http://192.168.50.234:5000/api/personas/${personaId}`);
+      await axios.post(`${API_BASE}/api/personas/${personaId}`);
       setCurrentPersona(personaId);
       
       // Add system message about persona change
@@ -93,7 +95,7 @@ export default function App() {
     setMessages(prev => [...prev, userMessage]);
     
     try {
-      const res = await axios.post('http://192.168.50.234:5000/api/chat', {
+      const res = await axios.post(`${API_BASE}/api/chat`, {
         message,
         session_id: sessionId,
         persona: currentPersona,
@@ -138,7 +140,7 @@ export default function App() {
     setError('');
     if (sessionId) {
       try {
-        await axios.delete(`http://192.168.50.234:5000/api/memory/session/${sessionId}`);
+        await axios.delete(`${API_BASE}/api/memory/session/${sessionId}`);
         setSessionId(null);
       } catch (err) {
         console.error('Error clearing session:', err);
@@ -148,7 +150,7 @@ export default function App() {
 
   const flushMemory = async () => {
     try {
-      await axios.post('http://192.168.50.234:5000/api/memory/flush');
+      await axios.post(`${API_BASE}/api/memory/flush`);
       setMessages(prev => [...prev, {
         role: 'system',
         content: '🧠 Short-term memory has been flushed',
@@ -162,7 +164,7 @@ export default function App() {
 
   const exportAnalytics = async () => {
     try {
-      const res = await axios.get('http://192.168.50.234:5000/api/logs/export');
+      const res = await axios.get(`${API_BASE}/api/logs/export`);
       alert(`Analytics exported to: ${res.data.export_path}`);
     } catch (err) {
       setError('Failed to export analytics');

--- a/dolphin_backend.py
+++ b/dolphin_backend.py
@@ -87,7 +87,6 @@ class ChatResponse(BaseModel):
     timestamp: str
     session_id: str
     persona_used: str
-    timestamp: str
 
 class TaskRoute(BaseModel):
     task_type: str


### PR DESCRIPTION
## Summary
- remove duplicate field in `ChatResponse`
- make gateway URL configurable via `VITE_GATEWAY_URL`
- restrict allowed origins with new `ALLOWED_ORIGINS` env
- document gateway configuration

## Testing
- `pytest -q` *(fails: import errors)*

------
https://chatgpt.com/codex/tasks/task_e_6888078c48888321984bb9b7d6916d8c