### PR TITLE
Add idle self-training initiator

### DIFF
--- a/idle_watchdog.py
+++ b/idle_watchdog.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Idle Watchdog
+
+Monitors user activity and initiates self-training when the system has been idle
+for an extended period. The watchdog checks for idle state every five minutes
+and respects the ``IDLE_THRESHOLD_MINUTES`` environment variable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timedelta
+
+import psutil
+
+from mirror_mode import get_mirror_mode_manager
+from trigger_self_train import trigger_self_training
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+IDLE_THRESHOLD_MINUTES = int(os.getenv("IDLE_THRESHOLD_MINUTES", "30"))
+CHECK_INTERVAL_SECONDS = 300  # five minutes
+
+
+class IdleWatchdog:
+    """Watchdog that triggers self-training when the user is idle."""
+
+    def __init__(self, idle_minutes: int = IDLE_THRESHOLD_MINUTES):
+        self.idle_threshold = timedelta(minutes=idle_minutes)
+        self.last_active_time = datetime.now()
+        self.running = False
+
+    def mark_active(self) -> None:
+        """Record a user activity event."""
+        self.last_active_time = datetime.now()
+        logger.debug("User activity recorded")
+
+    async def start(self) -> None:
+        """Begin monitoring for idle state."""
+        self.running = True
+        logger.info("Idle watchdog started")
+        while self.running:
+            await asyncio.sleep(CHECK_INTERVAL_SECONDS)
+            await self._check_idle()
+
+    def stop(self) -> None:
+        """Stop monitoring for idle state."""
+        self.running = False
+        logger.info("Idle watchdog stopped")
+
+    async def _check_idle(self) -> None:
+        """Check if the system has been idle long enough to trigger training."""
+        idle_duration = datetime.now() - self.last_active_time
+        cpu_usage = psutil.cpu_percent(interval=None)
+        logger.info(
+            "Idle check → %.0f seconds idle | CPU %.1f%%",
+            idle_duration.total_seconds(),
+            cpu_usage,
+        )
+
+        if idle_duration >= self.idle_threshold:
+            mirror = get_mirror_mode_manager()
+            if mirror and getattr(mirror, "is_enabled", False):
+                logger.info("Mirror mode active; skipping self-training trigger")
+                return
+
+            logger.info("Idle threshold exceeded; initiating self-training")
+            await trigger_self_training()
+
+
+idle_watchdog = IdleWatchdog()
+
+if __name__ == "__main__":
+    asyncio.run(idle_watchdog.start())

--- a/memory_system.py
+++ b/memory_system.py
@@ -450,3 +450,20 @@ class MemorySystem:
                     })
         
         return results[:20]  # Limit results
+
+    def get_recent_memories(self, limit: int = 100) -> List[Dict[str, Any]]:
+        """Return the most recent memory interactions.
+
+        Parameters
+        ----------
+        limit : int, optional
+            Maximum number of memory events to fetch, by default 100.
+
+        Returns
+        -------
+        List[Dict[str, Any]]
+            The latest memory entries ordered from oldest to newest within the
+            provided limit.
+        """
+        recent = self.short_term_memory.get("recent_interactions", [])
+        return recent[-limit:]

--- a/trigger_self_train.py
+++ b/trigger_self_train.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Self-Training Trigger
+
+Invoked by :mod:`idle_watchdog` when the system has been idle long enough.
+This module gathers recent memories, runs the reflection engine, and optionally
+notifies an n8n workflow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, List
+
+import aiohttp
+
+from memory_system import MemorySystem
+from reflection_engine import initialize_reflection_engine
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+ENABLE_N8N = os.getenv("ENABLE_N8N", "False").lower() == "true"
+N8N_WEBHOOK = os.getenv("N8N_WEBHOOK", "http://localhost:5678/webhook/self_train_trigger")
+
+
+async def trigger_self_training() -> None:
+    """Launch the reflection engine using recent memories."""
+    memory_system = MemorySystem()
+    engine = initialize_reflection_engine(memory_system, None)
+
+    try:
+        memory_batch: List[Any] = memory_system.get_recent_memories()
+    except AttributeError:
+        memory_batch = memory_system.short_term_memory.get("recent_interactions", [])[-100:]
+
+    if hasattr(engine, "run"):
+        await engine.run(memory_batch)
+    else:
+        # Fallback for older engines
+        if hasattr(engine, "_generate_reflections"):
+            engine.reflection_queue.extend(memory_batch)
+            await engine._generate_reflections()
+
+    logger.info("Self-training routine completed")
+
+    if ENABLE_N8N:
+        await _dispatch_n8n_webhook(len(memory_batch))
+
+
+async def _dispatch_n8n_webhook(count: int) -> None:
+    """Send a webhook notification to n8n if integration is enabled."""
+    try:
+        async with aiohttp.ClientSession() as session:
+            await session.post(N8N_WEBHOOK, json={"processed_memories": count})
+        logger.info("n8n webhook dispatched")
+    except Exception as exc:
+        logger.error("Failed to dispatch n8n webhook: %s", exc)
+
+
+if __name__ == "__main__":
+    asyncio.run(trigger_self_training())


### PR DESCRIPTION
## Summary
- implement `get_recent_memories` helper in `memory_system.py`
- add daemon `idle_watchdog.py` for idle monitoring
- add `trigger_self_train.py` to launch reflection engine

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError: cannot import name 'GoodbyeType')*

------
https://chatgpt.com/codex/tasks/task_e_6888d7b356888321a3ef1d98776f1fce