### PR TITLE
Implement memory pattern reflection engine

### DIFF
--- a/insight_schema.py
+++ b/insight_schema.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, Any
+import uuid
+
+@dataclass
+class Insight:
+    """Data model for a reflection insight."""
+
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+    type: str = ""
+    context: str = ""
+    emotion_vector: Dict[str, float] = field(default_factory=dict)
+    details: str = ""
+    intensity: float = 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "timestamp": self.timestamp.isoformat(),
+            "type": self.type,
+            "context": self.context,
+            "emotion_vector": self.emotion_vector,
+            "details": self.details,
+            "intensity": self.intensity,
+        }

--- a/pattern_utils.py
+++ b/pattern_utils.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pandas as pd
+from typing import List, Dict, Any
+
+
+def group_memories(memories: List[Dict[str, Any]], keys: List[str]) -> Dict[str, pd.DataFrame]:
+    """Group memory dicts by the given keys using pandas."""
+    if not memories:
+        return {}
+    df = pd.DataFrame(memories)
+    for key in keys:
+        if key not in df.columns:
+            df[key] = None
+    grouped = df.groupby(keys)
+    return {str(name): group for name, group in grouped}
+
+
+def smooth_series(series: pd.Series, window: int = 3) -> pd.Series:
+    """Return rolling mean of the series for smoothing."""
+    return series.rolling(window=window, min_periods=1).mean()
+
+
+def emotional_shift(values: List[float]) -> float:
+    """Return shift between first and last value in a list."""
+    if not values:
+        return 0.0
+    return values[-1] - values[0]


### PR DESCRIPTION
## Summary
- add dataclass for insight objects
- add utilities for grouping and smoothing memory data
- extend `reflection_engine.py` with a new `MemoryPatternReflectionEngine`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'GoodbyeType')*

------
https://chatgpt.com/codex/tasks/task_e_6888dbaeec048321bb01b1ea72c74f11