### PR TITLE
Implement connectivity adaptation manager

### DIFF
--- a/analytics_logger.py
+++ b/analytics_logger.py
@@ -30,6 +30,7 @@ class AnalyticsLogger:
         self.performance_log_file = self.logs_dir / "performance_metrics.jsonl"
         self.analytics_file = self.logs_dir / "analytics_summary.json"
         self.route_map_file = self.logs_dir / "routing_map.jsonl"
+        self.custom_events_file = self.logs_dir / "custom_events.jsonl"
         
         # In-memory buffers for real-time analytics
         self.recent_requests = deque(maxlen=1000)  # Last 1000 requests
@@ -161,6 +162,16 @@ class AnalyticsLogger:
                 f.write(json.dumps(data) + '\n')
         except Exception as e:
             logger.error(f"Error writing to log file {file_path}: {e}")
+
+    def log_custom_event(self, event_type: str, data: Dict[str, Any]):
+        """Record a custom analytics event"""
+        entry = {
+            "timestamp": datetime.now().isoformat(),
+            "event": event_type,
+            "data": data,
+        }
+        self._append_to_jsonl(self.custom_events_file, entry)
+        return entry
     
     def get_real_time_stats(self) -> Dict[str, Any]:
         """Get real-time analytics summary"""

--- a/fallback_personas.py
+++ b/fallback_personas.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from typing import Dict
+
+@dataclass
+class FallbackPersona:
+    """Template for emergency fallback personas."""
+    name: str
+    system_prompt: str
+    behavior: str
+
+
+_FALLBACK_PERSONAS: Dict[str, FallbackPersona] = {
+    "safe_mode": FallbackPersona(
+        name="Safe Mode",
+        system_prompt=(
+            "System is in emergency fallback mode. Keep responses brief, clear, and "
+            "avoid speculative statements. Prioritize user safety and reliability."
+        ),
+        behavior="resilient",
+    )
+}
+
+
+def get(persona_name: str) -> FallbackPersona:
+    """Retrieve a fallback persona configuration by name."""
+    return _FALLBACK_PERSONAS.get(persona_name, _FALLBACK_PERSONAS["safe_mode"])

--- a/handler_registry.py
+++ b/handler_registry.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, List, Optional
+from datetime import datetime
+
+
+class HandlerState(str, Enum):
+    ONLINE = "online"
+    DEGRADED = "degraded"
+    OFFLINE = "offline"
+
+
+@dataclass
+class HandlerInfo:
+    name: str
+    state: HandlerState = HandlerState.ONLINE
+    latency_ms: Optional[int] = None
+    errors: int = 0
+    last_checked: Optional[datetime] = None
+
+
+class HandlerRegistry:
+    """Registry of backend handlers and their states."""
+
+    def __init__(self) -> None:
+        self.handlers: Dict[str, HandlerInfo] = {}
+
+    def register(self, name: str) -> None:
+        if name not in self.handlers:
+            self.handlers[name] = HandlerInfo(name=name)
+
+    def update(self, name: str, state: HandlerState, latency_ms: Optional[int] = None, errors: int = 0) -> None:
+        self.register(name)
+        info = self.handlers[name]
+        info.state = state
+        info.latency_ms = latency_ms
+        info.errors = errors
+        info.last_checked = datetime.utcnow()
+
+    def get(self, name: str) -> HandlerInfo:
+        self.register(name)
+        return self.handlers[name]
+
+    def best_available(self, preferred_order: List[str]) -> str:
+        for name in preferred_order:
+            info = self.handlers.get(name)
+            if info and info.state != HandlerState.OFFLINE:
+                return name
+        return preferred_order[0]
+
+
+# Global registry instance
+handler_registry = HandlerRegistry()


### PR DESCRIPTION
## Summary
- add fallback personas
- implement handler registry for service status
- update connectivity manager with logging, emergency mode, and callbacks
- extend analytics logger with `log_custom_event`
- update backend to expose handler status update and fallback alert endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6888deff1dac83218a01d2d8de77b9b2