### PR TITLE
Add emotion-aware response optimizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,7 @@ unified_companion*.log
 # OS
 .DS_Store
 Thumbs.db
+
+# Emotion optimizer logs
+logs/emotion_trace.jsonl
+

--- a/emotion_engine.py
+++ b/emotion_engine.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Simple emotion token generator.
+Provides adjectives, emojis, and metaphors based on valence and arousal.
+"""
+
+from typing import Tuple
+
+
+POS_ADJECTIVES = ["joyful", "cheerful", "uplifting", "bright"]
+NEG_ADJECTIVES = ["somber", "gloomy", "downcast", "heavy"]
+NEU_ADJECTIVES = ["calm", "steady", "balanced"]
+
+POS_EMOJIS_HIGH = "😄"
+POS_EMOJIS_LOW = "🙂"
+NEG_EMOJIS_HIGH = "😠"
+NEG_EMOJIS_LOW = "😢"
+NEU_EMOJI = "😐"
+
+
+def choose_adjective(valence: float, arousal: float) -> str:
+    """Return an adjective reflecting the emotion."""
+    if valence > 0.3:
+        base = POS_ADJECTIVES
+    elif valence < -0.3:
+        base = NEG_ADJECTIVES
+    else:
+        base = NEU_ADJECTIVES
+    idx = int(abs(arousal) * (len(base) - 1))
+    return base[min(idx, len(base) - 1)]
+
+
+def choose_emoji(valence: float, arousal: float) -> str:
+    """Return an emoji matching valence/arousal."""
+    if valence > 0.3:
+        return POS_EMOJIS_HIGH if arousal > 0.5 else POS_EMOJIS_LOW
+    if valence < -0.3:
+        return NEG_EMOJIS_HIGH if arousal > 0.5 else NEG_EMOJIS_LOW
+    return NEU_EMOJI
+
+
+def choose_metaphor(valence: float) -> str:
+    """Return a short metaphor capturing mood."""
+    if valence > 0.3:
+        return "like sunshine breaking through clouds"
+    if valence < -0.3:
+        return "like walking through a storm"
+    return "like standing in a quiet room"

--- a/emotion_optimizer.py
+++ b/emotion_optimizer.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+"""Emotion-Aware Response Optimizer.
+Combines emotional signals, persona templates and backend generation
+into a tailored response.
+"""
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional, Any
+
+import aiohttp
+
+from emotion_engine import choose_adjective, choose_emoji, choose_metaphor
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EmotionSignature:
+    valence: float
+    arousal: float
+    persona: str
+    system_state: str
+
+
+class EmotionOptimizer:
+    def __init__(self, template_dir: str = "response_templates", log_file: str = "logs/emotion_trace.jsonl", backend_url: str = "http://localhost:8000"):
+        self.template_dir = Path(template_dir)
+        self.log_file = Path(log_file)
+        self.backend_url = backend_url
+
+    def _load_templates(self, persona: str) -> Dict[str, Any]:
+        tpl_path = self.template_dir / f"{persona.lower()}.json"
+        if not tpl_path.exists():
+            return {}
+        with open(tpl_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    async def optimize(self, user_message: str, system_emotion: Dict[str, float], user_emotion: Dict[str, float], active_persona: str, system_state: str = "normal", context_summary: Optional[str] = None) -> Dict[str, Any]:
+        templates = self._load_templates(active_persona)
+        valence = (user_emotion.get("valence", 0.0) * 0.6) + (system_emotion.get("valence", 0.0) * 0.4)
+        arousal = (user_emotion.get("arousal", 0.5) + system_emotion.get("arousal", 0.5)) / 2
+        adjective = choose_adjective(valence, arousal)
+        emoji = choose_emoji(valence, arousal)
+
+        if valence > 0.3:
+            mood_key = "positive"
+        elif valence < -0.3:
+            mood_key = "negative"
+        else:
+            mood_key = "neutral"
+
+        state_templates = templates.get(system_state, templates.get("normal", {}))
+        template = state_templates.get(mood_key) or state_templates.get("any") or "{message}"
+
+        base = template.format(adjective=adjective, emoji=emoji, context=context_summary or "")
+
+        payload = {"prompt": base + "\n" + (user_message or "")}
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(f"{self.backend_url}/generate_adaptive_response", json=payload) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        response_text = data.get("response", base)
+                    else:
+                        response_text = base
+        except Exception as e:
+            logger.warning(f"Backend request failed: {e}")
+            response_text = base
+
+        signature = EmotionSignature(valence=valence, arousal=arousal, persona=active_persona, system_state=system_state)
+        self._log_signature(signature, user_message)
+
+        return {"response": response_text, "signature": signature.__dict__}
+
+    def _log_signature(self, signature: EmotionSignature, message: str) -> None:
+        entry = {
+            "message": message,
+            "signature": signature.__dict__,
+        }
+        self.log_file.parent.mkdir(exist_ok=True)
+        with open(self.log_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+

--- a/response_templates/analyst.json
+++ b/response_templates/analyst.json
@@ -1,0 +1,10 @@
+{
+  "normal": {
+    "positive": "Data indicates positive trends. {emoji}",
+    "negative": "The metrics show some issues; let's analyze. {emoji}",
+    "neutral": "Here's the summary as requested. {emoji}"
+  },
+  "degraded": {
+    "any": "System resources low. Basic report follows. {emoji}"
+  }
+}

--- a/response_templates/coach.json
+++ b/response_templates/coach.json
@@ -1,0 +1,10 @@
+{
+  "normal": {
+    "positive": "Great job! Stay {adjective} and keep going! {emoji}",
+    "negative": "Let's channel that {adjective} energy into action. {emoji}",
+    "neutral": "Remember, consistent effort leads to progress. {emoji}"
+  },
+  "degraded": {
+    "any": "Apologies, I'm having difficulties, but keep pushing forward. {emoji}"
+  }
+}

--- a/response_templates/companion.json
+++ b/response_templates/companion.json
@@ -1,0 +1,13 @@
+{
+  "normal": {
+    "positive": "I'm so {adjective} to hear that! {emoji}",
+    "negative": "I'm here for you. It's okay to feel {adjective}. {emoji}",
+    "neutral": "Tell me more about how you're feeling. {emoji}"
+  },
+  "degraded": {
+    "any": "I'm having some trouble, but I want you to know I care. {emoji}"
+  },
+  "emergency": {
+    "any": "Please stay safe. If this is an emergency, reach out for help immediately. {emoji}"
+  }
+}

--- a/tests/test_emotion_optimizer.py
+++ b/tests/test_emotion_optimizer.py
@@ -1,0 +1,46 @@
+import asyncio
+import os
+import json
+import unittest
+import sys
+
+# Ensure project root is in path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from emotion_engine import choose_adjective, choose_emoji
+from emotion_optimizer import EmotionOptimizer
+
+
+class TestEmotionEngine(unittest.TestCase):
+    def test_adjective_choice(self):
+        adj = choose_adjective(0.8, 0.6)
+        self.assertIsInstance(adj, str)
+        self.assertNotEqual(adj, "")
+
+    def test_emoji_choice(self):
+        emoji = choose_emoji(-0.5, 0.2)
+        self.assertEqual(emoji, "😢")
+
+
+class TestEmotionOptimizer(unittest.TestCase):
+    def setUp(self):
+        self.optimizer = EmotionOptimizer(template_dir="response_templates")
+
+    def test_optimize_basic(self):
+        loop = asyncio.get_event_loop()
+        result = loop.run_until_complete(
+            self.optimizer.optimize(
+                "I had a bad day",
+                {"valence": 0.2, "arousal": 0.4},
+                {"valence": -0.6, "arousal": 0.7},
+                "Companion",
+            )
+        )
+        self.assertIn("response", result)
+        self.assertIn("signature", result)
+        self.assertIsInstance(result["signature"], dict)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- implement simple emotion token generator (adjectives, emojis, metaphors)
- add emotion-aware optimizer that selects templates and calls backend
- provide response templates for Companion, Coach and Analyst
- unit tests for emotion optimizer
- ignore optimizer log file

## Testing
- `pytest tests/test_emotion_optimizer.py -q`
- `pytest -q` *(fails: import errors in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_6888e0dc02bc832187d20571ba7278a2