### PR TITLE
Add stub simulation and judge agents

### DIFF
--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -1,0 +1,19 @@
+"""Base classes for Dolphin specialized agents."""
+
+from typing import Any, List, Optional
+
+
+class BaseAgent:
+    """Common functionality for specialized agents."""
+
+    def __init__(self, memory_system: Optional[Any] = None) -> None:
+        self.memory_system = memory_system
+        self.emotion_scores = {}  # TODO: Connect to emotion engine for scoring
+        # TODO: Include future training scaffolds
+
+    def recall(self, query: str) -> List[Any]:
+        """Return memories related to the query."""
+        if self.memory_system:
+            return self.memory_system.recall(query)
+        # TODO: integrate with memory recall system
+        return []

--- a/agents/judge_agent.py
+++ b/agents/judge_agent.py
@@ -1,0 +1,22 @@
+"""Agent capable of evaluating system outputs or behaviors."""
+
+from typing import Any
+
+from .base_agent import BaseAgent
+
+
+class JudgeAgent(BaseAgent):
+    """Evaluate outputs or behaviors using defined criteria."""
+
+    def evaluate(self, output: Any) -> Any:
+        """Assess a given output or behavior.
+
+        Args:
+            output: The content or behavior to evaluate.
+
+        Returns:
+            An evaluation score or structured report.
+        """
+        # TODO: integrate memory recall for contextual evaluation
+        # TODO: utilize emotion_scores and future training scaffolds
+        raise NotImplementedError

--- a/agents/simulation_agent.py
+++ b/agents/simulation_agent.py
@@ -1,0 +1,22 @@
+"""Agent capable of simulating alternate scenarios or decisions."""
+
+from typing import Any
+
+from .base_agent import BaseAgent
+
+
+class SimulationAgent(BaseAgent):
+    """Simulate hypothetical outcomes based on provided scenarios."""
+
+    def run_simulation(self, scenario: Any) -> Any:
+        """Run a hypothetical simulation for the given scenario.
+
+        Args:
+            scenario: Description of the scenario or decision set to explore.
+
+        Returns:
+            The result of the simulation.
+        """
+        # TODO: incorporate memory recall to inform simulations
+        # TODO: adjust emotion_scores based on simulated outcomes
+        raise NotImplementedError


### PR DESCRIPTION
## Summary
- add `agents` package with `BaseAgent`
- implement `SimulationAgent` and `JudgeAgent` skeletons inheriting from `BaseAgent`
- include docstrings and TODOs for memory recall and emotion integration

## Testing
- `pytest -k "simulation_agent or judge_agent" -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6888fb8d172c8321a91d50935cc4ec65