### PR TITLE
Add JudgeAgent evaluation utilities

### DIFF
--- a/evaluation_criteria.py
+++ b/evaluation_criteria.py
@@ -1,0 +1,13 @@
+"""Evaluation criteria enumeration for JudgeAgent."""
+
+from enum import Enum
+
+
+class EvaluationCriterion(Enum):
+    """Criteria used for evaluating generated content."""
+
+    EMOTIONAL_FIDELITY = "emotional_fidelity"
+    PERSONA_ALIGNMENT = "persona_alignment"
+    NARRATIVE_COHERENCE = "narrative_coherence"
+    MEMORY_CONGRUENCE = "memory_congruence"
+    ARTISTIC_EXPRESSION = "artistic_expression"

--- a/judge_agent.py
+++ b/judge_agent.py
@@ -1,0 +1,40 @@
+"""JudgeAgent - Evaluates AI generated responses using qualitative criteria."""
+
+from typing import Any, Dict
+
+from evaluation_criteria import EvaluationCriterion
+
+
+class JudgeAgent:
+    """Scores content against various evaluation criteria."""
+
+    def evaluate(self, content: str, context: Dict[str, Any] | None = None) -> Dict[EvaluationCriterion, float]:
+        """Return a score for each evaluation criterion."""
+        context = context or {}
+        return {
+            EvaluationCriterion.EMOTIONAL_FIDELITY: self._score_emotion(content, context),
+            EvaluationCriterion.PERSONA_ALIGNMENT: self._score_persona(content, context),
+            EvaluationCriterion.NARRATIVE_COHERENCE: self._score_narrative(content, context),
+            EvaluationCriterion.MEMORY_CONGRUENCE: self._score_memory(content, context),
+            EvaluationCriterion.ARTISTIC_EXPRESSION: self._score_artistry(content, context),
+        }
+
+    def _score_emotion(self, content: str, context: Dict[str, Any]) -> float:
+        """Placeholder scoring for emotional fidelity."""
+        return 0.5
+
+    def _score_persona(self, content: str, context: Dict[str, Any]) -> float:
+        """Placeholder scoring for persona alignment."""
+        return 0.5
+
+    def _score_narrative(self, content: str, context: Dict[str, Any]) -> float:
+        """Placeholder scoring for narrative coherence."""
+        return 0.5
+
+    def _score_memory(self, content: str, context: Dict[str, Any]) -> float:
+        """Placeholder scoring for memory congruence."""
+        return 0.5
+
+    def _score_artistry(self, content: str, context: Dict[str, Any]) -> float:
+        """Placeholder scoring for artistic expression."""
+        return 0.5


### PR DESCRIPTION
## Summary
- define `EvaluationCriterion` enum for quality metrics
- add `JudgeAgent` class with an `evaluate` method and stub scoring helpers

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'GoodbyeType' from 'goodbye_manager')*

------
https://chatgpt.com/codex/tasks/task_e_6888fc2154e8832187f72aa7cbf1d071