### PR TITLE
Add preference voting endpoint

### DIFF
--- a/core1-gateway/server.js
+++ b/core1-gateway/server.js
@@ -139,7 +139,8 @@ const apiEndpoints = [
   { path: '/api/logs/search', method: 'GET' },
   { path: '/api/logs/export', method: 'GET' },
   { path: '/api/system/cleanup', method: 'POST' },
-  { path: '/api/system/health', method: 'GET' }
+  { path: '/api/system/health', method: 'GET' },
+  { path: '/api/vote_preference', method: 'POST' }
 ];
 
 // Create proxy routes

--- a/core1-gateway/src/App.jsx
+++ b/core1-gateway/src/App.jsx
@@ -3,6 +3,7 @@
 
 import { useState, useEffect } from 'react';
 import axios from 'axios';
+import ComparisonVote from './ComparisonVote.jsx';
 
 const API_BASE = import.meta.env.VITE_GATEWAY_URL || 'http://localhost:5000';
 

--- a/core1-gateway/src/ComparisonVote.jsx
+++ b/core1-gateway/src/ComparisonVote.jsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import axios from 'axios';
+
+const API_BASE = import.meta.env.VITE_GATEWAY_URL || 'http://localhost:5000';
+
+export default function ComparisonVote({ input, original, candidate }) {
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState('');
+
+  const submitVote = async (winner) => {
+    try {
+      await axios.post(`${API_BASE}/api/vote_preference`, {
+        input,
+        response_a: original,
+        response_b: candidate,
+        winner,
+      });
+      setSubmitted(true);
+    } catch (err) {
+      setError('Failed to submit vote');
+    }
+  };
+
+  if (submitted) {
+    return <div className="bg-gray-800 p-4 rounded">Thanks for your feedback!</div>;
+  }
+
+  return (
+    <div className="bg-gray-800 p-4 rounded space-y-4">
+      <div className="text-sm text-gray-400">Which response do you prefer?</div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="p-3 rounded bg-gray-700">
+          <div className="font-semibold mb-2">Response A</div>
+          <pre className="whitespace-pre-wrap text-sm">{original}</pre>
+          <button onClick={() => submitVote('a')} className="mt-2 bg-blue-600 px-3 py-1 rounded text-sm hover:bg-blue-500">Choose A</button>
+        </div>
+        <div className="p-3 rounded bg-gray-700">
+          <div className="font-semibold mb-2">Response B</div>
+          <pre className="whitespace-pre-wrap text-sm">{candidate}</pre>
+          <button onClick={() => submitVote('b')} className="mt-2 bg-blue-600 px-3 py-1 rounded text-sm hover:bg-blue-500">Choose B</button>
+        </div>
+      </div>
+      <button onClick={() => submitVote('skip')} className="text-xs text-gray-400 underline">Skip</button>
+      {error && <div className="text-red-400 text-sm">{error}</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `<ComparisonVote>` component for picking between responses
- log human preference votes in a new SQLite table via `/api/vote_preference`
- initialize vote table on API startup and add backend vote endpoint
- proxy the new endpoint through the gateway server
- expose `ComparisonVote` for React app

## Testing
- `pytest -q` *(fails: ImportError in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_688908164db48321a82ab44414216e6f