### PR TITLE
Implement Emotion Eval Mode scaffolding

### DIFF
--- a/frontend/components/EmotionEvalVote.tsx
+++ b/frontend/components/EmotionEvalVote.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+
+interface EmotionEvalVoteProps {
+  prompt: string;
+  responseA: string;
+  responseB: string;
+  onVoted?: () => void;
+}
+
+export const EmotionEvalVote: React.FC<EmotionEvalVoteProps> = ({ prompt, responseA, responseB, onVoted }) => {
+  const [winner, setWinner] = useState<'a' | 'b' | ''>('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const submitVote = async () => {
+    if (!winner) return;
+    setSubmitting(true);
+    try {
+      await fetch('/api/vote_preference', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          prompt,
+          response_a: responseA,
+          response_b: responseB,
+          winner,
+        }),
+      });
+      if (onVoted) onVoted();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="emotion-eval-vote">
+      <p className="prompt">{prompt}</p>
+      <div className="responses">
+        <label>
+          <input type="radio" name="vote" disabled={submitting} onChange={() => setWinner('a')} />
+          <span>A: {responseA}</span>
+        </label>
+        <label>
+          <input type="radio" name="vote" disabled={submitting} onChange={() => setWinner('b')} />
+          <span>B: {responseB}</span>
+        </label>
+      </div>
+      <button onClick={submitVote} disabled={!winner || submitting}>Submit</button>
+    </div>
+  );
+};
+
+export default EmotionEvalVote;

--- a/frontend/components/index.ts
+++ b/frontend/components/index.ts
@@ -1,0 +1,1 @@
+export { EmotionEvalVote } from './EmotionEvalVote';

--- a/utils/preference_vote_store.py
+++ b/utils/preference_vote_store.py
@@ -1,0 +1,99 @@
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+# Label for internal reference
+EMOTION_EVAL_LABEL = "Emotion Eval Mode"
+
+
+@dataclass
+class PreferenceVote:
+    prompt: str
+    response_a: str
+    response_b: str
+    winner: str  # 'a' or 'b'
+    timestamp: str
+
+
+class PreferenceVoteStore:
+    """Store preference votes using SQLite and/or JSONL."""
+
+    def __init__(self, storage_dir: str = "data", use_sqlite: bool = True, use_jsonl: bool = True):
+        self.storage_path = Path(storage_dir)
+        self.storage_path.mkdir(parents=True, exist_ok=True)
+        self.use_sqlite = use_sqlite
+        self.use_jsonl = use_jsonl
+        self.sqlite_path = self.storage_path / "preference_votes.db"
+        self.jsonl_path = self.storage_path / "preference_votes.jsonl"
+
+        logger.info("%s initialized", EMOTION_EVAL_LABEL)
+
+    async def initialize(self) -> None:
+        if self.use_sqlite:
+            await self._init_sqlite()
+
+    async def _init_sqlite(self) -> None:
+        async with aiosqlite.connect(self.sqlite_path.as_posix()) as db:
+            await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS preference_votes (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp TEXT NOT NULL,
+                    prompt TEXT NOT NULL,
+                    response_a TEXT NOT NULL,
+                    response_b TEXT NOT NULL,
+                    winner TEXT NOT NULL
+                )
+                """
+            )
+            await db.commit()
+        logger.info("PreferenceVoteStore SQLite initialized at %s", self.sqlite_path)
+
+    async def record_vote(self, prompt: str, response_a: str, response_b: str, winner: str) -> bool:
+        vote = PreferenceVote(
+            prompt=prompt,
+            response_a=response_a,
+            response_b=response_b,
+            winner=winner,
+            timestamp=datetime.utcnow().isoformat(),
+        )
+        try:
+            if self.use_sqlite:
+                await self._save_sqlite(vote)
+            if self.use_jsonl:
+                self._save_jsonl(vote)
+            return True
+        except Exception as exc:
+            logger.error("Failed to record preference vote: %s", exc)
+            return False
+
+    async def _save_sqlite(self, vote: PreferenceVote) -> None:
+        async with aiosqlite.connect(self.sqlite_path.as_posix()) as db:
+            await db.execute(
+                """
+                INSERT INTO preference_votes (timestamp, prompt, response_a, response_b, winner)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (vote.timestamp, vote.prompt, vote.response_a, vote.response_b, vote.winner),
+            )
+            await db.commit()
+
+    def _save_jsonl(self, vote: PreferenceVote) -> None:
+        entry = {
+            "timestamp": vote.timestamp,
+            "prompt": vote.prompt,
+            "response_a": vote.response_a,
+            "response_b": vote.response_b,
+            "winner": vote.winner,
+        }
+        with open(self.jsonl_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+


### PR DESCRIPTION
## Summary
- add preference vote store with SQLite/JSONL support
- expose `/api/vote_preference` endpoint in backend
- initialize voting store on startup
- scaffold React `EmotionEvalVote` component

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6889089018748321b7c22f9677af84f9