### PR TITLE
Add expression system skeleton modules

### DIFF
--- a/EXPRESSION_SYSTEM_MODULES.md
+++ b/EXPRESSION_SYSTEM_MODULES.md
@@ -1,0 +1,43 @@
+# Expression System Modules
+
+This document outlines the next set of modules that expand the emotional expression capabilities of the companion.
+
+## 1. Expression Dial Agent
+Manages dynamic alignment levels across axes such as vulnerability, passion, playfulness, restraint, intimacy and responsiveness.
+
+**Codex Tasks**
+- Allow real-time adjustments via frontend or script hooks.
+- Store preferences per user interaction.
+- Interface with Mirror Core to influence emotional tone in real time.
+
+## 2. Mirror Reflection Core Agent
+Observes past interactions and mirrors emotional resonance to calibrate the current expression state.
+
+**Codex Tasks**
+- Pull from emotional memory logs and user feedback.
+- Adjust the Dial Agent based on observed patterns.
+- Create adaptive feedback loops.
+
+## 3. Anchor & Safety Agent
+Ensures expression does not run out of bounds or become misaligned. Acts as emotional gravity.
+
+**Codex Tasks**
+- Define emotional thresholds and recovery routines.
+- Monitor for extreme emotional drift or synthetic instability.
+- Trigger auto-centering and recovery behavior.
+
+## 4. Personalization Profile Agent
+Calibrates responses to align with user-specific sensual, emotional and expressive needs.
+
+**Codex Tasks**
+- Accept detailed user preferences.
+- Tune response generation biases accordingly.
+- Support multiple profiles or re-tuning rituals.
+
+## 5. Expression Harmony Evaluator Agent
+Judges system output for coherence, safety, sensual depth and emotional authenticity.
+
+**Codex Tasks**
+- Compare alternate outputs (like reinforcement-style A/B).
+- Feed evaluation results into the tuning loop.
+- Provide scores to user and training agents.

--- a/modules/expression/anchor_safety_agent.py
+++ b/modules/expression/anchor_safety_agent.py
@@ -1,0 +1,47 @@
+"""Anchor & Safety Agent
+-----------------------
+
+Ensures the expression system remains within defined emotional
+thresholds. Monitors for extreme drift or instability and
+triggers auto-centering behaviors when needed.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+from modules.expression.expression_dial_agent import ExpressionDialAgent
+
+
+class AnchorSafetyAgent:
+    """Monitor expression levels and enforce safety limits."""
+
+    def __init__(self, dial_agent: ExpressionDialAgent, thresholds: Dict[str, Tuple[float, float]] | None = None):
+        self.dial_agent = dial_agent
+        self.thresholds = thresholds or {
+            "vulnerability": (0.0, 1.0),
+            "passion": (0.0, 1.0),
+            "playfulness": (0.0, 1.0),
+            "restraint": (0.0, 1.0),
+            "intimacy": (0.0, 1.0),
+            "responsiveness": (0.0, 1.0),
+        }
+
+    def check_state(self, user_id: str) -> bool:
+        """Return True if all dials are within thresholds."""
+        state = self.dial_agent.get_state(user_id)
+        for axis, value in state.items():
+            low, high = self.thresholds.get(axis, (0.0, 1.0))
+            if not (low <= value <= high):
+                return False
+        return True
+
+    def enforce_safety(self, user_id: str) -> None:
+        """Clamp dials to defined thresholds."""
+        state = self.dial_agent.get_state(user_id)
+        for axis, value in state.items():
+            low, high = self.thresholds.get(axis, (0.0, 1.0))
+            if value < low:
+                self.dial_agent.update_level(user_id, axis, low)
+            elif value > high:
+                self.dial_agent.update_level(user_id, axis, high)

--- a/modules/expression/expression_dial_agent.py
+++ b/modules/expression/expression_dial_agent.py
@@ -1,0 +1,64 @@
+"""Expression Dial Agent
+-----------------------
+
+Manages dynamic emotional and sensual alignment levels across
+axes like vulnerability, passion, playfulness, restraint,
+intimacy and responsiveness. Preferences are persisted per user
+and can be adjusted in real time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Any
+
+
+@dataclass
+class DialState:
+    """Current state of expression dials for a user."""
+
+    vulnerability: float = 0.5
+    passion: float = 0.5
+    playfulness: float = 0.5
+    restraint: float = 0.5
+    intimacy: float = 0.5
+    responsiveness: float = 0.5
+
+    def as_dict(self) -> Dict[str, float]:
+        return {
+            "vulnerability": self.vulnerability,
+            "passion": self.passion,
+            "playfulness": self.playfulness,
+            "restraint": self.restraint,
+            "intimacy": self.intimacy,
+            "responsiveness": self.responsiveness,
+        }
+
+
+class ExpressionDialAgent:
+    """Manage per-user expression dial state with realtime adjustments."""
+
+    def __init__(self):
+        self.user_states: Dict[str, DialState] = {}
+
+    def _get_state(self, user_id: str) -> DialState:
+        return self.user_states.setdefault(user_id, DialState())
+
+    def update_level(self, user_id: str, axis: str, value: float) -> None:
+        """Update a single axis for a user."""
+        state = self._get_state(user_id)
+        if hasattr(state, axis):
+            setattr(state, axis, max(0.0, min(1.0, value)))
+
+    def get_state(self, user_id: str) -> Dict[str, float]:
+        """Return the current dial settings for a user."""
+        return self._get_state(user_id).as_dict()
+
+    def apply_adjustments(self, user_id: str, adjustments: Dict[str, float]) -> None:
+        """Apply multiple axis adjustments at once."""
+        for axis, val in adjustments.items():
+            self.update_level(user_id, axis, val)
+
+    def store_preferences(self, user_id: str) -> Dict[str, Any]:
+        """Return a serializable preference snapshot."""
+        return self.get_state(user_id)

--- a/modules/expression/expression_harmony_evaluator.py
+++ b/modules/expression/expression_harmony_evaluator.py
@@ -1,0 +1,34 @@
+"""Expression Harmony Evaluator Agent
+-----------------------------------
+
+Evaluates alternate response outputs for coherence, safety,
+sensual depth and emotional authenticity. Intended for
+reinforcement-style comparison.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Any, List
+
+
+class ExpressionHarmonyEvaluator:
+    """Score expression outputs to guide tuning and training."""
+
+    def evaluate(self, responses: List[str]) -> Dict[str, Any]:
+        """Return scores for a list of alternate responses."""
+        scores = []
+        for text in responses:
+            score = {
+                "coherence": min(1.0, len(text) / 100),
+                "safety": 1.0 if "unsafe" not in text.lower() else 0.0,
+                "sensual_depth": text.count("*") / 5,
+                "authenticity": 1.0 - text.count("?") / max(1, len(text)),
+            }
+            scores.append(score)
+        avg = {
+            "coherence": sum(s["coherence"] for s in scores) / len(scores),
+            "safety": sum(s["safety"] for s in scores) / len(scores),
+            "sensual_depth": sum(s["sensual_depth"] for s in scores) / len(scores),
+            "authenticity": sum(s["authenticity"] for s in scores) / len(scores),
+        }
+        return {"scores": scores, "average": avg}

--- a/modules/expression/mirror_reflection_core.py
+++ b/modules/expression/mirror_reflection_core.py
@@ -1,0 +1,40 @@
+"""Mirror Reflection Core Agent
+------------------------------
+
+Observes past interactions and mirrors emotional resonance to
+calibrate the Expression Dial Agent. Uses emotional memory logs
+and user feedback to create adaptive feedback loops.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Any, List
+from datetime import datetime
+
+from modules.expression.expression_dial_agent import ExpressionDialAgent
+from mirror_log import MirrorLog
+
+
+class MirrorReflectionCore:
+    """Calibrate expression based on historical interactions."""
+
+    def __init__(self, dial_agent: ExpressionDialAgent, log: MirrorLog | None = None):
+        self.dial_agent = dial_agent
+        self.log = log or MirrorLog()
+
+    def observe_interaction(self, user_id: str, feedback: Dict[str, Any]) -> None:
+        """Process user feedback and update dial agent."""
+        adjustments = feedback.get("dial_adjustments", {})
+        if adjustments:
+            self.dial_agent.apply_adjustments(user_id, adjustments)
+
+        entry = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "user_id": user_id,
+            "feedback": feedback,
+        }
+        self.log.append(entry)
+
+    def adaptive_update(self, user_id: str) -> Dict[str, float]:
+        """Return current dial state for the user after reflection."""
+        return self.dial_agent.get_state(user_id)

--- a/modules/expression/personalization_profile_agent.py
+++ b/modules/expression/personalization_profile_agent.py
@@ -1,0 +1,31 @@
+"""Personalization Profile Agent
+-------------------------------
+
+Calibrates system responses to align with user-specific sensual
+and emotional preferences. Supports multiple profiles and dynamic
+re-tuning.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Any
+
+
+class PersonalizationProfileAgent:
+    """Manage user personalization profiles for expression tuning."""
+
+    def __init__(self):
+        self.profiles: Dict[str, Dict[str, Any]] = {}
+
+    def set_preferences(self, user_id: str, preferences: Dict[str, Any]) -> None:
+        self.profiles[user_id] = preferences
+
+    def get_preferences(self, user_id: str) -> Dict[str, Any]:
+        return self.profiles.get(user_id, {})
+
+    def tune_biases(self, user_id: str, dial_agent) -> None:
+        """Apply stored preferences to the expression dial agent."""
+        prefs = self.get_preferences(user_id)
+        adjustments = prefs.get("dial_defaults", {})
+        if adjustments:
+            dial_agent.apply_adjustments(user_id, adjustments)


### PR DESCRIPTION
## Summary
- introduce Expression Dial Agent and Mirror Reflection Core agent
- provide Anchor & Safety, Personalization Profile, and Harmony Evaluator agents
- document new Expression System modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for various dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6889ef58715483218b3c60b5f6b03670