### PR TITLE
Integrate N8nAgent into routing

### DIFF
--- a/agents/n8n_agent.py
+++ b/agents/n8n_agent.py
@@ -1,0 +1,37 @@
+from typing import Dict, Any
+import aiohttp
+import logging
+
+logger = logging.getLogger(__name__)
+
+class N8nAgent:
+    """Simple agent to trigger n8n workflows via webhooks."""
+
+    def __init__(self, base_url: str = "http://localhost:5678") -> None:
+        self.base_url = base_url.rstrip('/')
+        # default workflow mapping
+        self.workflow_routes: Dict[str, str] = {
+            "create_reminder": f"{self.base_url}/webhook/create-reminder"
+        }
+
+    def register_workflow(self, name: str, url: str) -> None:
+        self.workflow_routes[name] = url
+
+    async def execute(self, workflow: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute a workflow and return JSON response."""
+        url = self.workflow_routes.get(workflow)
+        if not url:
+            raise ValueError(f"Unknown workflow: {workflow}")
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, json=payload) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        return {"success": True, "data": data}
+                    else:
+                        text = await resp.text()
+                        logger.error("n8n workflow %s failed: %s", workflow, text)
+                        return {"success": False, "error": f"HTTP {resp.status}"}
+        except Exception as e:
+            logger.error("n8n request error: %s", e)
+            return {"success": False, "error": str(e)}

--- a/dolphin_backend.py
+++ b/dolphin_backend.py
@@ -1,0 +1,7 @@
+from dolphin_backend.main import app
+
+if __name__ == "__main__":
+    import uvicorn
+    import os
+    port = int(os.getenv('DOLPHIN_PORT', 8000))
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/dolphin_backend/routes/chat.py
+++ b/dolphin_backend/routes/chat.py
@@ -18,9 +18,12 @@ async def status_endpoint():
         async with aiohttp.ClientSession() as session:
             async with session.get(f"{orchestrator.ollama_url}/api/tags") as response:
                 ollama_status = response.status == 200
+            async with session.get(f"{orchestrator.n8n_url}/healthz") as n8n_resp:
+                n8n_status = n8n_resp.status == 200
 
     except Exception:
         ollama_status = False
+        n8n_status = False
     analytics = orchestrator.analytics_logger.get_real_time_stats()
     memory_summary = orchestrator.memory_system.get_memory_summary()
     return {
@@ -30,7 +33,7 @@ async def status_endpoint():
             "services": {
                 "ollama": ollama_status,
                 "openrouter_configured": bool(orchestrator.openrouter_key),
-                "n8n": False
+                "n8n": n8n_status
             },
             "analytics": analytics,
             "memory": memory_summary,
@@ -61,7 +64,7 @@ async def handlers_endpoint():
                 "name": "N8N",
                 "description": "Workflow automation and utilities",
                 "icon": "🔧",
-                "status": "development"
+                "status": "available" if orchestrator.n8n_url else "unavailable"
             },
             {
                 "name": "KIMI_K2",


### PR DESCRIPTION
## Summary
- implement `N8nAgent` for triggering n8n webhooks
- instantiate agent in orchestrator and call it for utility tasks
- add n8n connectivity check to status endpoint
- expose FastAPI app via `dolphin_backend.py`

## Testing
- `pytest -q` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688a3325dc708321938f91f16866ac44